### PR TITLE
prefetch 비동기로 처리

### DIFF
--- a/app/(pages)/[user]/[id]/page.tsx
+++ b/app/(pages)/[user]/[id]/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import { Suspense } from 'react';
 import { notFound } from 'next/navigation';
 import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
 
@@ -13,7 +12,6 @@ import { getQueryClient } from '@/app/utils/utils';
 
 import Header from './_components/PostHeader';
 import PostContextProvider from './_providers/PostContextProvider';
-import PostPageSkeleton from './_components/PostPageSkeleton';
 
 interface ParamsType {
   id: string;
@@ -46,17 +44,16 @@ async function Page({ params }: { params: Promise<ParamsType> }) {
   try {
     const queryClient = getQueryClient();
 
-    queryClient.prefetchQuery(getPostCategoryOptions(id));
-    queryClient.prefetchQuery(getPostDetailOptions(id, user));
-
-    const recordMap = await getPage(id);
+    const [, , recordMap] = await Promise.all([
+      queryClient.prefetchQuery(getPostCategoryOptions(id)),
+      queryClient.prefetchQuery(getPostDetailOptions(id, user)),
+      getPage(id),
+    ]);
 
     return (
       <HydrationBoundary state={dehydrate(queryClient)}>
         <PostContextProvider user={user} id={id} recordMap={recordMap}>
-          <Suspense fallback={<PostPageSkeleton />}>
-            <Header />
-          </Suspense>
+          <Header />
           <NotionPageRenderer recordMap={recordMap} user={user} />
         </PostContextProvider>
       </HydrationBoundary>

--- a/app/(pages)/[user]/[id]/page.tsx
+++ b/app/(pages)/[user]/[id]/page.tsx
@@ -44,10 +44,11 @@ async function Page({ params }: { params: Promise<ParamsType> }) {
   try {
     const queryClient = getQueryClient();
 
-    queryClient.prefetchQuery(getPostCategoryOptions(id));
-    queryClient.prefetchQuery(getPostDetailOptions(id, user));
-
-    const recordMap = await getPage(id);
+    const [, , recordMap] = await Promise.all([
+      queryClient.prefetchQuery(getPostCategoryOptions(id)),
+      queryClient.prefetchQuery(getPostDetailOptions(id, user)),
+      getPage(id),
+    ]);
 
     return (
       <HydrationBoundary state={dehydrate(queryClient)}>


### PR DESCRIPTION
- streaming 처리 시 [react 310](https://react.dev/errors/310)에러 발생
- 일단 prefetch 비동기로 처리
- 그럼 왜 streaming 방식으로 데이터 가져오면? 안되지?
  - 가설
    - 데이터 받아오는대로 useQuery가 처리되어야하는데 안됐다?
      - 그래서 서버단에서 prefetch후 streaming이 완료되어 useQuery가 실행되어 310에러 발생?
      - 근데 내가 suspense로 비동기 처리를 안해줘서?
      - 일단 app 레이어쪽에 해봤는데 처리 안됨
    - 서버액션이 사용되어서?
      - 프론트서버에서 prefetch를 하는데, 호출하는곳이 프론트서버의 서버액션
    - next이슈에 있는대로 서버 액션에서 에러 발생
      - 이슈에서는 서버단에서 redirect시 발생
      - 서버에서 prefetch하는 상황이랑 비슷
        - 그럼 useQuery가 실행되어 310은 아닌건가? 다른 원인?
        - next redirect 구현 확인해보기
     - 걍 서버액션쪽에서 문제 발생중
       - 일단 화나는건 production 환경에서만 발생


- 일단 해결을 위해 prefetch 비동기 병렬 처리
  - 조금 시간손해 